### PR TITLE
Dev/sanhe/1.0.11

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+## Title
+
+Please **pick a concise, informative and complete title** for your PR.
+
+## Motivation
+
+Please explain the motivation behind this PR in the description.
+
+If you're fixing a bug, link to the issue number like so:
+
+```
+- Fixes #{issue_number}
+```
+
+If you're adding a new feature, then consider opening a issue and discussing it with the maintainers (GitHub Username ``MacHu-GWU``) before you actually do the hard work.
+
+## Tests
+
+If you're fixing a bug, consider [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development):
+
+1. Create a unit test that demonstrates the bug. The test should **fail**.
+2. Implement your bug fix.
+3. The test you created should now **pass**.
+
+If you're implementing a new feature, include unit tests for it.
+
+Make sure all existing unit tests pass.
+
+## Work in progress
+
+If you're still working on your PR, include "WIP" in the title.
+We'll skip reviewing it for the time being.
+Once you're ready to review, remove the "WIP" from the title, and ping one of the maintainers (e.g. mpenkov).
+
+## Checklist
+
+Before you create the PR, please make sure you have:
+
+- [ ] Picked a concise, informative and complete title
+- [ ] Clearly explained the motivation behind the PR
+- [ ] Linked to any existing issues that your PR will be solving
+- [ ] Included tests for any new functionality
+- [ ] Checked that all unit tests pass
+
+## Workflow
+
+Please avoid rebasing and force-pushing to the branch of the PR once a review is in progress.
+Rebasing can make your commits look a bit cleaner, but it also makes life more difficult from the reviewer, because they are no longer able to distinguish between code that has already been reviewed, and unreviewed code.

--- a/docs/source/01-Pure-S3-Path-Manipulation/index.rst
+++ b/docs/source/01-Pure-S3-Path-Manipulation/index.rst
@@ -2,7 +2,6 @@
 
 Pure S3 Path Manipulation
 ==============================================================================
-
 .. contents::
     :class: this-will-duplicate-information-and-it-is-still-useful-here
     :depth: 1
@@ -53,6 +52,24 @@ Construct a S3 Path
     # construct from string, auto join parts
     >>> S3Path("bucket", "folder", "subfolder/")
     S3Path('s3://bucket/folder/subfolder/')
+
+``/`` **is a Python Operator Override Syntax Sugar, it is the Pythonic way to Construct a Path**.
+
+.. code-block:: python
+
+    >>> s3path_bucket = S3Path("bucket")
+    >>> s3path_bucket / "folder/"
+    S3Path('s3://bucket/folder/')
+
+    # You can chain "/" together
+    >>> s3path_bucket / "folder" / "file.txt"
+    S3Path('s3://bucket/folder/file.txt')
+
+    # it work with list too
+    >>> s3path_bucket / ["folder", "file.txt"]
+    S3Path('s3://bucket/folder/file.txt')
+
+It works with :ref:`relative-path` too.
 
 **Summary**:
 
@@ -192,8 +209,14 @@ Logically a :class:`~s3pathlib.core.S3Path` is also a file system like object. S
 
 S3 Path Methods
 ------------------------------------------------------------------------------
-**Identify S3Path type**
+.. contents::
+    :class: this-will-duplicate-information-and-it-is-still-useful-here
+    :depth: 1
+    :local:
 
+
+Identify S3Path type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :meth:`~s3pathlib.core.S3Path.is_dir`:
 
 .. code-block:: python
@@ -229,8 +252,8 @@ S3 Path Methods
     >>> S3Path("bucket", "folder/").relative_to(S3Path("bucket")).is_relpath()
     True
 
-**Comparison**
-
+Comparison
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Since S3Path can convert to S3 URI, it should be able to compare to each other.
 
 .. code-block:: python
@@ -256,8 +279,8 @@ Since S3Path can convert to S3 URI, it should be able to compare to each other.
     >>> S3Path("bucket/a/1.txt") < S3Path("bucket/a/2.txt")
     True
 
-**Hash**
-
+Hash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``S3Path`` is :meth:`hashable <~s3pathlib.core.S3Path.__hash__>`.
 
 .. code-block:: python
@@ -280,8 +303,9 @@ Since S3Path can convert to S3 URI, it should be able to compare to each other.
     >>> set1.difference(set2)
     {S3Path('s3://bucket/1.txt')}
 
-**Mutate the immutable S3Path**
 
+Mutate the immutable S3Path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :meth:`~s3pathlib.core.S3Path.copy`: create a copy of this S3Path, but completely different because it is immutable.
 
 .. code-block:: python
@@ -356,8 +380,10 @@ Since S3Path can convert to S3 URI, it should be able to compare to each other.
     >>> p3.join_path(relpath2, relpath1)
     S3Path('s3://bucket/folder/subfolder/file.txt')
 
-**Parent relationship**
+.. _relative-path:
 
+Relative Path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :meth:`~s3pathlib.core.S3Path.relative_to`: calculate the relative path between two path, the "to path" has to be "shorter than" the "from path"
 
 .. code-block:: python
@@ -371,10 +397,17 @@ Since S3Path can convert to S3 URI, it should be able to compare to each other.
     >>> S3Path("bucket", "a").relative_to(S3Path("bucket", "a/b/c")).parts
     ValueError ...
 
+- The ``-`` operator override provide a syntax sugar for ``relative_to`` method
+
+.. code-block:: python
+
+    >>> S3Path("bucket", "a/b/c") - S3Path("bucket", "a")
+    ['b', 'c']
+
+
 
 What's Next
 ------------------------------------------------------------------------------
-
 Since then everything is not talking to AWS yet, let's learn how to make some AWS S3 API call using ``s3pathlib``.
 
 Go :ref:`stateless-s3-api`

--- a/release-history.rst
+++ b/release-history.rst
@@ -4,13 +4,26 @@ Release and Version History
 ==============================================================================
 
 
-1.0.11 (TODO)
+1.0.12 (TODO)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Features and Improvements**
 
 - :class:`s3pathlib.aws.Context` object is now singleton.
 - allow ``and_``, ``or_``, ``not_`` in iterproxy filter.
 - add tagging management feature
+
+**Minor Improvements**
+
+**Bugfixes**
+
+**Miscellaneous**
+
+
+1.0.11 (TODO)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Features and Improvements**
+
+- add the ``__truediv__`` operator override. it is a``s3path / part1 / part2`` syntax sugar.
 
 **Minor Improvements**
 

--- a/release-history.rst
+++ b/release-history.rst
@@ -10,7 +10,9 @@ Release and Version History
 
 - :class:`s3pathlib.aws.Context` object is now singleton.
 - allow ``and_``, ``or_``, ``not_`` in iterproxy filter.
-- add tagging management feature
+- add ``tagging`` management feature
+- add ``acl`` management feature
+- add ``legal_hold`` management feature
 
 **Minor Improvements**
 

--- a/release-history.rst
+++ b/release-history.rst
@@ -23,7 +23,8 @@ Release and Version History
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Features and Improvements**
 
-- add the ``__truediv__`` operator override. it is a``s3path / part1 / part2`` syntax sugar.
+- add the ``__truediv__`` operator override. it is a ``s3path / part1 / part2`` syntax sugar.
+- add the ``__sub__`` operator override. it is a ``S3Path("bucket/folder") - S3Path("bucket")`` syntax sugar.
 
 **Minor Improvements**
 

--- a/s3pathlib/__init__.py
+++ b/s3pathlib/__init__.py
@@ -7,10 +7,12 @@ Objective Oriented Interface for AWS S3, similar to pathlib.
 from ._version import __version__
 
 __short_description__ = "Objective Oriented Interface for AWS S3, similar to pathlib."
-__license__ = "MIT"
+__license__ = "Apache License 2.0"
 __author__ = "Sanhe Hu"
 __author_email__ = "husanhe@gmail.com"
-__github_username__ = "MacHu-GWU"
+__maintainer__ = "Sanhe Hu"
+__maintainer_email__ = "sanhehu@amazon.com"
+__github_username__ = "aws-samples"
 
 try:
     from . import utils

--- a/s3pathlib/_version.py
+++ b/s3pathlib/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.10"
+__version__ = "1.0.11"
 
 if __name__ == "__main__":  # pragma: no cover
     print(__version__)

--- a/s3pathlib/core.py
+++ b/s3pathlib/core.py
@@ -700,6 +700,8 @@ class S3Path:
             # relative path also work
             >>> S3Path("new-bucket") / (S3Path("bucket/file.txt").relative_to(S3Path("bucket")))
             S3Path('s3://new-bucket/file.txt')
+
+        .. versionadded:: 1.0.11
         """
         if self.is_void():
             raise TypeError("You cannot do ``VoidS3Path / other``!")
@@ -721,6 +723,8 @@ class S3Path:
         """
         A syntax sugar. Basically ``s3path1 - s3path2`` is equal to
         ``s3path2.relative_to(s3path1)``
+
+        .. versionadded:: 1.0.11
         """
         return self.relative_to(other)
 
@@ -1357,9 +1361,14 @@ class S3Path:
 
     def __repr__(self):
         classname = self.__class__.__name__
-        if self.is_relpath():
+
+        if self.is_void():
+            return "S3VoidPath()"
+
+        elif self.is_relpath():
+            key = self.key
             if len(key):
-                return f"S3RelPath({self.key!r})"
+                return f"S3RelPath({key!r})"
             else:
                 return "S3RelPath()"
         else:
@@ -2102,6 +2111,7 @@ class S3Path:
         opener=None,
         ignore_ext=False,
         compression=None,
+        api_kwargs: dict = None,
         bsm: Optional['BotoSesManager'] = None,
     ):
         """
@@ -2216,3 +2226,29 @@ class S3Path:
             for p in self.parents:
                 if p.is_bucket() is False:
                     p.mkdir(exist_ok=True, parents=False, bsm=bsm)
+
+    # --------------------------------------------------------------------------
+    #                         S3 Object Tagging
+    # --------------------------------------------------------------------------
+    __S5_TAGGING__ = None
+
+    def get_tagging(self, *args, **kwargs) -> dict:
+        raise NotImplementedError
+
+    def put_tagging(self, *args, **kwargs) -> dict:
+        raise NotImplementedError
+
+    def delete_tagging(self, *args, **kwargs) -> dict:
+        raise NotImplementedError
+
+    def get_acl(self, *args, **kwargs) -> dict:
+        raise NotImplementedError
+
+    def put_acl(self, *args, **kwargs) -> dict:
+        raise NotImplementedError
+
+    def get_legal_hold(self, *args, **kwargs) -> dict:
+        raise NotImplementedError
+
+    def put_legal_hold(self, *args, **kwargs) -> dict:
+        raise NotImplementedError

--- a/s3pathlib/core.py
+++ b/s3pathlib/core.py
@@ -373,7 +373,7 @@ class S3Path:
     # --------------------------------------------------------------------------
     #               Objective Oriented Programming Implementation
     # --------------------------------------------------------------------------
-    __OOP_IMPLEMENTATION__ = None
+    __S1_OOP_IMPLEMENTATION__ = None
 
     def __new__(
         cls,
@@ -583,7 +583,7 @@ class S3Path:
     # --------------------------------------------------------------------------
     #                Method that DOESN't need boto3 API call
     # --------------------------------------------------------------------------
-    __ATTRIBUTE_AND_METHOD__ = None
+    __S2_ATTRIBUTE_AND_METHOD__ = None
 
     def to_dict(self) -> dict:
         """
@@ -1449,7 +1449,7 @@ class S3Path:
     # --------------------------------------------------------------------------
     #                   Method that need boto3 API call
     # --------------------------------------------------------------------------
-    __STATELESS_API__ = None
+    __S3_STATELESS_API__ = None
 
     def clear_cache(self) -> None:
         """
@@ -1619,7 +1619,7 @@ class S3Path:
     # --------------------------------------------------------------------------
     #            Method that change the state of S3 bucket / objects
     # --------------------------------------------------------------------------
-    __STATEFUL_API__ = None
+    __S4_STATEFUL_API__ = None
 
     def upload_file(
         self,

--- a/s3pathlib/core.py
+++ b/s3pathlib/core.py
@@ -1355,11 +1355,10 @@ class S3Path:
     def __repr__(self):
         classname = self.__class__.__name__
         if self.is_relpath():
-            key = self.key
             if len(key):
-                return "{}('{}')".format(classname, key)
+                return f"S3RelPath({self.key!r})"
             else:
-                return "{}()".format(classname)
+                return "S3RelPath()"
         else:
             uri = self.uri
             return "{}('{}')".format(classname, uri)
@@ -1371,10 +1370,14 @@ class S3Path:
         """
         Return the relative path to another path. If the operation
         is not possible (because this is not a sub path of the other path),
-        raise ValueError.
+        raise ``ValueError``.
+
+        ``-`` is a syntax sugar for ``relative_to``. See more information at
+        :meth:`~S3Path.__sub__``.
 
         The relative path usually works with :meth:`join_path` to form a new
-        path.
+        path. Or you can use the ``/`` syntax sugar as well. See more
+        information at :meth:`~S3Path.__truediv__``.
 
         Examples::
 
@@ -1389,7 +1392,7 @@ class S3Path:
 
         :param other: other :class:`S3Path` instance.
 
-        :return: an relative path object, which is a special version of S3Path
+        :return: a relative path object, which is a special version of S3Path
 
         .. versionadded:: 1.0.1
         """

--- a/s3pathlib/core.py
+++ b/s3pathlib/core.py
@@ -72,6 +72,9 @@ class S3PathIterProxy(IterProxy):
     def all(self) -> List['S3Path']:
         return super(S3PathIterProxy, self).all()
 
+    def skip(self, k: int) -> 'S3PathIterProxy':
+        return super(S3PathIterProxy, self).skip(k=k)
+
     def filter_by_ext(self, *exts: str) -> 'S3PathIterProxy':
         """
         Filter S3 object by file extension. Case is insensitive.
@@ -1373,11 +1376,11 @@ class S3Path:
         raise ``ValueError``.
 
         ``-`` is a syntax sugar for ``relative_to``. See more information at
-        :meth:`~S3Path.__sub__``.
+        :meth:`~S3Path.__sub__`.
 
         The relative path usually works with :meth:`join_path` to form a new
         path. Or you can use the ``/`` syntax sugar as well. See more
-        information at :meth:`~S3Path.__truediv__``.
+        information at :meth:`~S3Path.__truediv__`.
 
         Examples::
 

--- a/s3pathlib/core.py
+++ b/s3pathlib/core.py
@@ -673,6 +673,47 @@ class S3Path:
             self._hash = hash(tuple(self._cparts))
             return self._hash
 
+    def __truediv__(
+        self,
+        other: Union[
+            str,
+            'S3Path',
+            List[Union[str, 'S3Path']]
+        ]
+    ) -> 'S3Path':
+        """
+        A syntax sugar. Basically ``S3Path(s3path, part1, part2, ...)``
+        is equal to ``s3path / part1 / part2 / ...`` or
+        ``s3path / [part1, part2]``
+
+        Example::
+
+            >>> S3Path("bucket") / "folder" / "file.txt"
+            S3Path('s3://bucket/folder/file.txt')
+
+            >>> S3Path("bucket") / ["folder", "file.txt"]
+            S3Path('s3://bucket/folder/file.txt')
+
+            # relative path also work
+            >>> S3Path("new-bucket") / (S3Path("bucket/file.txt").relative_to(S3Path("bucket")))
+            S3Path('s3://new-bucket/file.txt')
+        """
+        if self.is_void():
+            raise TypeError("You cannot do ``VoidS3Path / other``!")
+        if isinstance(other, list):
+            res = self
+            for part in other:
+                res = res / part
+            return res
+        else:
+            if (
+                self.is_relpath()
+                and isinstance(other, S3Path)
+                and other.is_relpath() is False
+            ):
+                raise TypeError("you cannot do ``RelativeS3Path / NonRelativeS3Path``!")
+            return S3Path(self, other)
+
     def copy(self) -> 'S3Path':
         """
         Create an duplicate copy of S3Path object that logically equals to

--- a/s3pathlib/core.py
+++ b/s3pathlib/core.py
@@ -714,6 +714,13 @@ class S3Path:
                 raise TypeError("you cannot do ``RelativeS3Path / NonRelativeS3Path``!")
             return S3Path(self, other)
 
+    def __sub__(self, other: 'S3Path') -> 'S3Path':
+        """
+        A syntax sugar. Basically ``s3path1 - s3path2`` is equal to
+        ``s3path2.relative_to(s3path1)``
+        """
+        return self.relative_to(other)
+
     def copy(self) -> 'S3Path':
         """
         Create an duplicate copy of S3Path object that logically equals to

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,8 @@ if __name__ == "__main__":
     CLASSIFIERS = [
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License Version 2.0",
+        "Intended Audience :: Amazon Web Service User",
         "Natural Language :: English",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from s3pathlib import S3Path
+
+
+@pytest.fixture
+def bucket() -> S3Path:
+    return S3Path("bucket")
+
+
+@pytest.fixture
+def directory() -> S3Path:
+    return S3Path("bucket", "folder/")
+
+
+@pytest.fixture
+def file() -> S3Path:
+    return S3Path("bucket", "folder", "file.txt")
+
+
+@pytest.fixture
+def relpath() -> S3Path:
+    return S3Path("bucket", "folder", "file.txt").relative_to(S3Path("bucket"))
+
+
+@pytest.fixture
+def void() -> S3Path:
+    return S3Path()

--- a/tests/test_core_2_property.py
+++ b/tests/test_core_2_property.py
@@ -68,7 +68,7 @@ class TestS3Path:
         assert p.arn is None
         assert p.console_url is None
         assert p.us_gov_cloud_console_url is None
-        assert str(p) == "S3Path()"
+        assert str(p) == "S3VoidPath()"
         assert p.basename == ""
         with pytest.raises(ValueError):
             _ = p.fname
@@ -88,7 +88,7 @@ class TestS3Path:
         assert p.uri is None
         assert p.arn is None
         assert p.console_url is None
-        assert str(p) == "S3Path('folder/file.txt')"
+        assert str(p) == "S3RelPath('folder/file.txt')"
         assert p.basename == "file.txt"
         assert p.fname == "file"
         assert p.ext == ".txt"

--- a/tests/test_core_3_method.py
+++ b/tests/test_core_3_method.py
@@ -390,6 +390,42 @@ class TestS3Path:
                 bucket=None, parts=["a", "b"], is_dir=None
             ).ensure_not_relpath()
 
+    def test_divide_operator(
+        self,
+        bucket,
+        directory,
+        file,
+        relpath,
+        void,
+    ):
+        assert bucket / "folder/" == directory
+        assert bucket / "folder" != directory
+        assert bucket / ["folder/", ] == directory
+        assert bucket / ["folder", "/"] == directory
+        assert bucket / ["folder", ] != directory
+
+        assert bucket / "folder" / "file.txt" == file
+        assert bucket / "folder/" / "file.txt" == file
+        assert bucket / "folder/" / "/file.txt" == file
+
+        assert bucket / ["folder", "file.txt"] == file
+        assert bucket / ["folder/", "file.txt"] == file
+        assert bucket / ["folder/", "/file.txt"] == file
+
+        assert bucket / relpath == file
+
+        root = S3Path("bucket")
+        rel1 = S3Path("bucket/folder/").relative_to(S3Path("bucket"))
+        rel2 = S3Path("bucket/folder/file.txt").relative_to(S3Path("bucket/folder/"))
+        assert root / [rel1, rel2] == S3Path("bucket/folder/file.txt")
+        assert root / (rel1 / rel2) == S3Path("bucket/folder/file.txt")
+
+        with pytest.raises(TypeError):  # relpath cannot / non-relpath
+            rel1 / root
+
+        with pytest.raises(TypeError):
+            void / "bucket"
+
 
 if __name__ == "__main__":
     import os

--- a/tests/test_core_3_method.py
+++ b/tests/test_core_3_method.py
@@ -426,7 +426,16 @@ class TestS3Path:
         with pytest.raises(TypeError):
             void / "bucket"
 
+    def test_sub_operator(
+        self,
+        bucket,
+        directory,
+        file,
+    ):
+        assert (directory - bucket) == directory.relative_to(bucket)
+        assert (file - directory) == file.relative_to(directory)
 
+        
 if __name__ == "__main__":
     import os
 


### PR DESCRIPTION
**Issue #, if available**:

NA, just about new version

**Description of changes**:

- [Summary in release history](https://github.com/aws-samples/s3pathlib-project/blob/dev/sanhe/1.0.11/release-history.rst#1011-todo)
- [``__truediv__`` and ``__sub__`` implementation](https://github.com/aws-samples/s3pathlib-project/blob/dev/sanhe/1.0.11/s3pathlib/core.py#L679)
- [unit test for ``/`` syntax sugar](https://github.com/aws-samples/s3pathlib-project/blob/dev/sanhe/1.0.11/tests/test_core_3_method.py#L393)
- [unit test for ``-`` syntax sugar](https://github.com/aws-samples/s3pathlib-project/blob/dev/sanhe/1.0.11/tests/test_core_3_method.py#L429)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.